### PR TITLE
docs: specify major version in jsDelivr url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,30 @@
 ## About
+
 SUIT―수트는 반복되는 노력을 기울이지 않아도 완성도 높은 형태를 유지하며, 소모적인 커뮤니케이션도 줄일 수 있도록 제작한 UI 본문용 폰트입니다.
 자세한 내용은 [소개 페이지](http://sun.fo/suit)에서 확인하세요.
 
-
-
 ## Download
+
 ### Static
+
 - [OTF](https://github.com/sun-typeface/SUIT/releases/latest/download/SUIT-otf.zip)
 - [TTF](https://github.com/sun-typeface/SUIT/releases/latest/download/SUIT-ttf.zip)
 - [WOFF2](https://github.com/sun-typeface/SUIT/releases/latest/download/SUIT-woff2.zip)
 
 ### Variable
+
 - [TTF](https://github.com/sun-typeface/SUIT/releases/latest/download/SUIT-Variable-ttf.zip)
 - [WOFF2](https://github.com/sun-typeface/SUIT/releases/latest/download/SUIT-Variable-woff2.zip)
 
-
 ## Webfont
+
 ### Static
+
 ```html
-<link href="https://cdn.jsdelivr.net/gh/sun-typeface/SUIT/fonts/static/woff2/SUIT.css" rel="stylesheet">
+<link
+  href="https://cdn.jsdelivr.net/gh/sun-typeface/SUIT@2/fonts/static/woff2/SUIT.css"
+  rel="stylesheet"
+/>
 
 <style>
   body { font-family: 'SUIT', sans-serif; }
@@ -26,22 +32,23 @@ SUIT―수트는 반복되는 노력을 기울이지 않아도 완성도 높은 
 ```
 
 ### Variable
+
 ```html
-<link href="https://cdn.jsdelivr.net/gh/sun-typeface/SUIT/fonts/variable/woff2/SUIT-Variable.css" rel="stylesheet">
+<link
+  href="https://cdn.jsdelivr.net/gh/sun-typeface/SUIT@2/fonts/variable/woff2/SUIT-Variable.css"
+  rel="stylesheet"
+/>
 
 <style>
   body { font-family: 'SUIT Variable', sans-serif; }
 </style>
 ```
 
-
-
-
 ## License
+
 SUIT―수트는 오픈소스입니다. [SIL 오픈 폰트 라이선스](https://scripts.sil.org/OFL)에 따라 자유롭게 사용하고 수정 및 재배포 할 수 있습니다.
 한글 글리프는 [본고딕](https://github.com/adobe-fonts/source-han-sans)을 기초로 합니다.
 
-
-
 ## Getting Involved
+
 폰트에 대한 제안은 검토를 위해 이슈로 등록해주시거나 i@sun.fo으로 보내주세요.


### PR DESCRIPTION
v2로 바뀌면서 영문 타입페이스가 대대적으로 바뀌었습니다. ([v1.2.5](https://github.com/sun-typeface/SUIT/releases/tag/v1.2.5) 릴리스 참고)

![image](https://github.com/sun-typeface/SUIT/assets/47051820/f092bb1e-19fb-401b-96c2-5848c01d9222)

REDAME 상에서 제공되는 jsDelivr 링크에는 버전이 명시돼있지 않아 무조건 최신 버전을 불러옵니다.

그래서 SUIT v1을 브랜딩 용도로 사용하던 기업에서 글꼴이 바뀌어 당황한 사례가 있음을 들었습니다.

README 상 CSS URL에 메이저 버전을 `@2`와 같이 명시해 이러한 문제를 피할 수 있도록 했습니다.

향후 v3 올릴 때만 수정하시면 됩니다.

---

버전을 명시하는 것은 [jsDelivr 권장사항](https://www.jsdelivr.com/documentation)이기도 합니다.

> Omit the version completely or use "latest" to load the latest one (not recommended for production usage):

```
/npm/jquery@latest/dist/jquery.min.js
/npm/jquery/dist/jquery.min.js
```

---

줄 바꿈 추가/삭제는 Markdown formatter 실행 결과에 따른 것이어서 우선 놔뒀습니다.