### PR TITLE
fix: match package.json version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sun-typeface/SUIT",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "repository": "https://github.com/sun-typeface/SUIT",
   "license": "OFL-1.1"
 }


### PR DESCRIPTION
https://github.com/sun-typeface/SUIT/releases/tag/v2.0.4

v2.0.4 버전이 배포됐음에도 `package.json` 파일이 수정되지 않았습니다.

## 부연

npm / pnpm 환경에서 GitHub 패키지를 업데이트하는 건 재설치하는 방법 뿐입니다. https://github.com/npm/npm/issues/1727#issuecomment-354124625

```shell
pnpm i github:sun-typeface/SUIT
```

다른 버전이 설치됐음에도 `pnpm-lock.yaml` 파일상 version 값이 그대로임을 확인할 수 있습니다.

```diff
 '@sun-typeface/SUIT@https://codeload.github.com/sun-typeface/SUIT/tar.gz/40880e31fb8b04e7ffce7b45d342eea9fe435cac':
-  resolution: {tarball: https://codeload.github.com/sun-typeface/SUIT/tar.gz/40880e31fb8b04e7ffce7b45d342eea9fe435cac}
+  resolution: {tarball: https://codeload.github.com/sun-typeface/SUIT/tar.gz/1c24b59b7dbcd9e70a990971760047ae6b4345bc}
   version: 2.0.3
```