### PR TITLE
NPM Publish 를 위한 정보 추가

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -22,6 +22,34 @@ npm install @sun-typeface/suit
 - [TTF](https://github.com/sun-typeface/SUIT/releases/latest/download/SUIT-Variable-ttf.zip)
 - [WOFF2](https://github.com/sun-typeface/SUIT/releases/latest/download/SUIT-Variable-woff2.zip)
 
+## Webfont
+
+### Static
+
+```html
+<link
+  href="https://cdn.jsdelivr.net/gh/sun-typeface/SUIT@2/fonts/static/woff2/SUIT.css"
+  rel="stylesheet"
+/>
+
+<style>
+  body { font-family: 'SUIT', sans-serif; }
+</style>
+```
+
+### Variable
+
+```html
+<link
+  href="https://cdn.jsdelivr.net/gh/sun-typeface/SUIT@2/fonts/variable/woff2/SUIT-Variable.css"
+  rel="stylesheet"
+/>
+
+<style>
+  body { font-family: 'SUIT Variable', sans-serif; }
+</style>
+```
+
 ## License
 
 SUIT―수트는 오픈소스입니다. [SIL 오픈 폰트 라이선스](https://scripts.sil.org/OFL)에 따라 자유롭게 사용하고 수정 및 재배포 할 수 있습니다.

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-sources/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+sources/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 SUIT―수트는 반복되는 노력을 기울이지 않아도 완성도 높은 형태를 유지하며, 소모적인 커뮤니케이션도 줄일 수 있도록 제작한 UI 본문용 폰트입니다.
 자세한 내용은 [소개 페이지](http://sun.fo/suit)에서 확인하세요.
 
+## Install
+
+```
+npm install @sun-typeface/suit
+```
+
 ## Download
 
 ### Static

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sun-typeface/suit",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "repository": "https://github.com/sun-typeface/SUIT",
   "homepage": "https://sun.fo/suit/",
   "author": "Sun",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "repository": "https://github.com/sun-typeface/SUIT",
   "homepage": "https://sun.fo/suit/",
   "author": "Sun",
-  "publishConfig": {
-    "access": "public"
-  },
-  "license": "OFL-1.1"
+  "license": "OFL-1.1",
+  "files": [
+    "fonts/"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
-  "name": "@sun-typeface/SUIT",
+  "name": "@sun-typeface/suit",
   "version": "2.0.4",
   "repository": "https://github.com/sun-typeface/SUIT",
+  "homepage": "https://sun.fo/suit/",
+  "author": "Sun",
+  "publishConfig": {
+    "access": "public"
+  },
   "license": "OFL-1.1"
 }


### PR DESCRIPTION
1. package.json 의 패키지 이름을 소문자로 변경했습니다.
npm 의 패키지 이름 정책은 대문자를 허용하지 않습니다.
https://docs.npmjs.com/creating-a-package-json-file#required-name-and-version-fields
> The "name" field contains your package's name, and must be lowercase and one word, and may contain hyphens and underscores.

2. package.json 에서 몇가지 정보를 추가했습니다.
* homepage
* author 

3. 2.0.4 버전과 혼선을 방지하기 위해 2.0.5 버전을 사용하도록 했습니다. 

4. `.npmignore` 에 `sources/` 를 추가해 publish 에서 제외했습니다.  (@hyunbinseo 님 제안)

5. GitHub 에 노출될 README 와 npm 에 노출될 README 를 나눴습니다. (@hyunbinseo 님 제안)
  * npm 에 노출되는 README 에는 웹폰트 관련 사항이 노출되지 않습니다.
  
이 PR 이 머지되면 앞으로 npm publish 가 원활해 질 것으로 기대합니다.

관련이슈: #13 

@hyunbinseo 제안 감사합니다.